### PR TITLE
Fix/mvd conditional value breakdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@
 
 /node_modules
 .env*
+
+#ignore csv data
+/db/data/*

--- a/app/views/scenarios/_breakdown.html.erb
+++ b/app/views/scenarios/_breakdown.html.erb
@@ -1,5 +1,5 @@
 <% value_breakdown = JSON.parse(@scenario.value_breakdown) %>
-
+<% if value_breakdown %>
 <div class="breakdown">
   Pipeline
   <div class="stacked-bar-chart">
@@ -60,3 +60,4 @@
     </li>
   </ul>
 </div>
+<% end %> 


### PR DESCRIPTION
- add condition to only show stacked bar chart in scenario detail page when value_breakdown exists. This is to avoid getting a 500 error page
-  add the paths of csv data to the gitignore
